### PR TITLE
remove networkpolicy from commonlabel defaults

### DIFF
--- a/pkg/transformers/config/defaultconfig/commonlabels.go
+++ b/pkg/transformers/config/defaultconfig/commonlabels.go
@@ -144,19 +144,4 @@ commonLabels:
   create: false
   group: policy
   kind: PodDisruptionBudget
-
-- path: spec/podSelector/matchLabels
-  create: false
-  group: networking.k8s.io
-  kind: NetworkPolicy
-
-- path: spec/ingress/from/podSelector/matchLabels
-  create: false
-  group: networking.k8s.io
-  kind: NetworkPolicy
-
-- path: spec/egress/to/podSelector/matchLabels
-  create: false
-  group: networking.k8s.io
-  kind: NetworkPolicy
 `


### PR DESCRIPTION
If we apply commonLabels to the spec of a networkpolicy it will alter
the policy so it no longer matchs what was applied.